### PR TITLE
Bump to go 1.23.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Tests
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 bin/
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
 ARG TARGETOS TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/pfnet-research/gcp-workload-identity-federation-webhook
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.23.10
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
This pull request includes updates to the CI workflow and upgrades the Go version used in the project. The most important changes involve renaming the CI workflow for clarity and updating the Go version across relevant files.

### CI Workflow Updates:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL1-R1): Renamed the CI workflow from "CI" to "CI Tests" for improved clarity.

### Go Version Upgrade:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the Go version from `1.22` to `1.23` in the build stage.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Upgraded the Go version from `1.22.0` to `1.23.10` and removed the `toolchain` directive for Go `1.22.5`.