### PR TITLE
fix: update kube-rbac-proxy to registry.k8s.io v0.16.0

### DIFF
--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -11,8 +11,8 @@ controllerManager:
 
   kubeRbacProxy:
     image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.11.0
+      repository: registry.k8s.io/kubebuilder/kube-rbac-proxy
+      tag: v0.16.0
     resources:
       limits:
         cpu: 500m

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The gcr.io/kubebuilder registry has been sunset and the kube-rbac-proxy:v0.11.0 image is no longer pullable, causing ImagePullBackOff on any new or restarted webhook pods.